### PR TITLE
fix list page filtering not working

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 	<main>
-		{{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
+		{{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
 		{{ range $paginator.Pages }}
 			{{ partial "summary.html" . }}
 		{{ end }}


### PR DESCRIPTION
When I started using the blank theme, I found urls like <http://example.com/tags/js> would list all posts instead of just posts tagged 'js' which is what I expected. Changing `.Site.Pages` to 'Data.Pages' fixes this, and now my site can have lists that filter posts by category and tags. Maybe this is useful for someone else too.

There's a discussion about the difference between `.Site.Pages` and `.Data.Pages` here: https://discourse.gohugo.io/t/whats-the-difference-between-site-pages-and-data-pages/2252

