### PR TITLE
add datetime attribute

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
 	<main>
 		<article>
 			<h1>{{ .Title }}</h1>
-			<time>{{ .Date.Format "02.01.2006 15:04" }}</time>
+			<time datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{ .Date.Format "02.01.2006" }}</time>
 			<div>
 				{{ .Content }}
 			</div>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,6 +1,6 @@
 <article>
 	<h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-	<time>{{ .Date.Format "02.01.2006 15:04" }}</time>
+	<time datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{ .Date.Format "02.01.2006" }}</time>
 	{{ range .Params.tags }}
 	<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
 	{{ end }}


### PR DESCRIPTION
First of all, I want to say that this theme is the best theme!

The current date isn't machine-readable because of the formatting. I've added a datetime attribute, so the date formatting between the tags can be anything, but the date can still be machine-readable for search engines, calendars, etc. I also changed the displayed date to follow the ISO 8601 standard.